### PR TITLE
[Library] Add sketch of timeline traits

### DIFF
--- a/python/openassetio_mediacreation/trait/__init__.py
+++ b/python/openassetio_mediacreation/trait/__init__.py
@@ -3,4 +3,70 @@
 """
 A collection of well-known traits for use within the Media Creation
 industry.
+
+Traits at this level may be used for multiple purposes. Those specific
+to certain applications are grouped into modules by use.
 """
+
+
+from typing import Union
+
+from openassetio import Trait
+
+
+class TimelineTrait(Trait):
+    """
+    This trait characterizes a collection of tracks that evaluate
+    concurrently to form layers of references to media. Frequently used
+    in non-linear editing environments such as Video and Audio post
+    production tools.
+    """
+
+    kId = "timeline"
+
+
+class TrackTrait(Trait):
+    """
+    This trait characterizes a lane or collection of media, arranged
+    temporally such that only a single item in the collection is active
+    at any given time. Frequently used in non-linear editing
+    environments such as Video and Audio post production tools.
+    """
+
+    kId = "track"
+
+
+class ClipTrait(Trait):
+    """
+    This trait characterizes the use of some range of external media,
+    commonly on a track or timeline. Frequently used in non-linear
+    editing environments such as Video and Audio production tools.
+
+    TODO(TC): Define any additional properties, and companion traits
+    such as 'frameRange' and 'handles'.
+    """
+
+    kId = "clip"
+
+    __kName = "name"
+
+    def setName(self, name: str):
+        """
+        Sets the name of the clip.
+        """
+        if not isinstance(name, str):
+            raise TypeError("name must be a string")
+        self._specification.setTraitProperty(self.kId, self.__kName, name)
+
+    def getName(self, defaultValue=None) -> Union[str, None]:
+        """
+        Returns the name of the clip or the defaultValue.
+        """
+        value = self._specification.getTraitProperty(self.kId, self.__kName)
+        if value is None:
+            return defaultValue
+        elif not isinstance(value, str):
+            if defaultValue is None:
+                raise TypeError(f"Invalid stored value type: '{value}' [{type(value).__name__}]")
+            return defaultValue
+        return value

--- a/tests/python/openassetio_mediacreation/trait/test___init__.py
+++ b/tests/python/openassetio_mediacreation/trait/test___init__.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2013-2022 The Foundry Visionmongers Ltd
+"""
+Basic tests for common entity traits.
+"""
+
+# pylint: disable=missing-function-docstring, missing-class-docstring
+# pylint: disable=no-self-use, redefined-outer-name, invalid-name
+# pylint: disable=too-few-public-methods,wrong-import-position
+
+import pytest
+
+from openassetio import Specification
+
+##
+## TimelineTrait
+##
+
+from openassetio_mediacreation.trait import TimelineTrait
+
+
+class Test_TimelineTrait:
+    def test_traitId(self):
+        assert TimelineTrait.kId == "timeline"
+
+
+##
+## TrackTrait
+##
+
+from openassetio_mediacreation.trait import TrackTrait
+
+
+class Test_TrackTrait:
+    def test_traitId(self):
+        assert TrackTrait.kId == "track"
+
+
+##
+## ClipTrait
+##
+
+from openassetio_mediacreation.trait import ClipTrait
+
+
+class Test_ClipTrait:
+    def test_traitId(self):
+        assert ClipTrait.kId == "clip"
+
+
+class Test_ClipTrait_name:
+    def test_when_spec_does_not_have_clip_trait_then_raises_IndexError(
+        self, an_empty_specification
+    ):
+        trait = ClipTrait(an_empty_specification)
+        with pytest.raises(IndexError):
+            trait.getName()
+
+    def test_when_name_property_is_set_then_returns_name(self, a_clip_specification):
+        expected = "yet another name"
+        a_clip_specification.setTraitProperty(ClipTrait.kId, "name", expected)
+        assert ClipTrait(a_clip_specification).getName() == expected
+
+    def test_when_name_property_not_set_then_returns_None(self, a_clip_specification):
+        assert ClipTrait(a_clip_specification).getName() is None
+
+    def test_when_name_property_is_not_set_and_default_provided_then_returns_default(
+        self, a_clip_specification
+    ):
+        default = "a default name"
+        actual = ClipTrait(a_clip_specification).getName(defaultValue=default)
+        assert actual == default
+
+    def test_when_name_property_has_wrong_type_and_no_default_provided_then_raises_TypeError(
+        self, a_clip_specification
+    ):
+        a_clip_specification.setTraitProperty(ClipTrait.kId, "name", 123)
+        with pytest.raises(TypeError) as err:
+            assert ClipTrait(a_clip_specification).getName()
+        assert str(err.value) == "Invalid stored value type: '123' [int]"
+
+    def test_when_name_property_has_wrong_value_type_and_default_provided_then_returns_default(
+        self, a_clip_specification
+    ):
+        a_clip_specification.setTraitProperty(ClipTrait.kId, "name", 123)
+        trait = ClipTrait(a_clip_specification)
+        default = "a default name"
+        assert trait.getName(defaultValue=default) == default
+
+
+class Test_ClipTrait_setName:
+    def test_when_spec_does_not_have_clip_trait_then_raises_IndexError(
+        self, an_empty_specification
+    ):
+        trait = ClipTrait(an_empty_specification)
+        with pytest.raises(IndexError):
+            trait.setName("a name")
+
+    def test_when_set_then_expected_trait_property_is_set(self, a_clip_specification):
+        trait = ClipTrait(a_clip_specification)
+        expected = "another name"
+        trait.setName(expected)
+        actual = a_clip_specification.getTraitProperty(ClipTrait.kId, "name")
+        assert actual == expected
+
+    def test_when_name_type_is_wrong_then_TypeError_is_raised(self, a_clip_specification):
+        trait = ClipTrait(a_clip_specification)
+        with pytest.raises(TypeError) as err:
+            trait.setName(123)
+        assert str(err.value) == "name must be a string"
+
+
+@pytest.fixture
+def an_empty_specification():
+    return Specification(set())
+
+
+@pytest.fixture
+def a_clip_specification():
+    return Specification({ClipTrait.kId})


### PR DESCRIPTION
Sketches of how timeline items may be represented. It raises the interesting question of whether some traits may be applicable to both entities and locales?

Committing to facilitate discussion, and enable the `otio-openassetio` PoC to switch to traits.